### PR TITLE
fix: Improve mobile tap detection for markers

### DIFF
--- a/script.js
+++ b/script.js
@@ -155,7 +155,7 @@ const attractions = [
 ];
 
 // Initialize the map and set its view to Albania
-var map = L.map('map').setView([41.1533, 20.1683], 7); // Coordinates for Albania and zoom level
+var map = L.map('map', { tap: false }).setView([41.1533, 20.1683], 7); // Coordinates for Albania and zoom level
 
 // Add a tile layer to the map (using OpenStreetMap)
 const baseLayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
I've set the `tap` option to `false` in the map initialization to improve the reliability of tap events on mobile devices. This should fix the issue where tapping on a marker does not open the popup on touch screens.