### PR TITLE
feat: Enrich user experience with auto-start onboarding tour

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,6 +11,7 @@ module.exports = defineConfig({
     baseURL: 'http://localhost:8080',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    actionTimeout: 10000,
   },
   projects: [
     {

--- a/script.js
+++ b/script.js
@@ -1243,4 +1243,16 @@ if (typeof TourSystem !== 'undefined') {
             tourSystem.start();
         });
     }
+
+    // Auto-start tour for new users (disabled during tests to prevent overlay blocking)
+    if (!window.__PLAYWRIGHT_TEST__) {
+        const hasSeenTour = localStorage.getItem('albania_tour_seen');
+        if (!hasSeenTour) {
+            // Use a short timeout to ensure the map and UI are fully rendered
+            setTimeout(() => {
+                tourSystem.start();
+                localStorage.setItem('albania_tour_seen', 'true');
+            }, 1000);
+        }
+    }
 }

--- a/tests/e2e/mission-control.spec.js
+++ b/tests/e2e/mission-control.spec.js
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Mission Control & Simulation', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__PLAYWRIGHT_TEST__ = true;
+    });
     await page.goto('/');
     await page.waitForSelector('.leaflet-container');
 

--- a/tests/e2e/user-journey.spec.js
+++ b/tests/e2e/user-journey.spec.js
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test';
 
 test.describe('User Journey', () => {
   test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      window.__PLAYWRIGHT_TEST__ = true;
+    });
     await page.goto('/');
     // Wait for map to load
     await page.waitForSelector('.leaflet-container');


### PR DESCRIPTION
This PR enriches the initial user experience by automatically starting the existing guided tour (TourSystem) the first time a user visits the application. It creates an engaging introduction to the map's features without adding any permanent buttons or UI clutter to the screen. 

To prevent the tour overlay from blocking clicks and causing flaky E2E tests, the test suites now inject a flag (`window.__PLAYWRIGHT_TEST__`) that disables the auto-start behavior during automated runs.

---
*PR created automatically by Jules for task [5835545064485311598](https://jules.google.com/task/5835545064485311598) started by @rajeshceg3*